### PR TITLE
Swapped version code and version name for mapping file.

### DIFF
--- a/release.go
+++ b/release.go
@@ -190,8 +190,8 @@ func (r Release) UploadSymbol(filePath string) error {
 			Version    string     `json:"version,omitempty"`
 		}{
 			FileName:   filepath.Base(filePath),
-			Build:      r.ShortVersion,
-			Version:    r.Version,
+			Build:      r.Version,
+			Version:    r.ShortVersion,
 			SymbolType: symbolType,
 		}
 		postResponse struct {


### PR DESCRIPTION
The version code and the version name seems to be swapped around on the uploaded mappings.txt file for Android builds. This causes incoming issues to not be de-obfuscated.

This PR swaps the version code and version name when uploading the mapping.txt file.

Hope that you will review it and incorporate it in the next version of the step, if you find it good.