### PR TITLE
Add all dist groups support

### DIFF
--- a/app.go
+++ b/app.go
@@ -40,6 +40,11 @@ func (a AppAPI) Groups(name string) (model.Group, error) {
 	return a.API.GetGroupByName(name, a.ReleaseOptions.App)
 }
 
+// AllGroups ...
+func (a AppAPI) AllGroups() ([]model.Group, error) {
+	return a.API.GetAllGroups(a.ReleaseOptions.App)
+}
+
 // Stores ...
 func (a AppAPI) Stores(name string) (model.Store, error) {
 	return a.API.GetStore(name, a.ReleaseOptions.App)

--- a/client/api.go
+++ b/client/api.go
@@ -79,6 +79,25 @@ func (api API) GetGroupByName(groupName string, app model.App) (model.Group, err
 	return getResponse, err
 }
 
+// GetAllGroups ...
+func (api API) GetAllGroups(app model.App) ([]model.Group, error) {
+	var (
+		getURL      = fmt.Sprintf("%s/v0.1/apps/%s/%s/distribution_groups", baseURL, app.Owner, app.AppName)
+		getResponse []model.Group
+	)
+
+	statusCode, err := api.Client.jsonRequest(http.MethodGet, getURL, nil, &getResponse)
+	if err != nil {
+		return []model.Group{}, err
+	}
+
+	if statusCode != http.StatusOK {
+		return []model.Group{}, fmt.Errorf("invalid status code: %d, url: %s, body: %v", statusCode, getURL, getResponse)
+	}
+
+	return getResponse, nil
+}
+
 // GetStore ...
 func (api API) GetStore(storeName string, app model.App) (model.Store, error) {
 	var (
@@ -485,7 +504,7 @@ func (api API) CreateRelease(opts model.ReleaseOptions) (int, error) {
 	return releaseDistinctID, nil
 }
 
-func getContentType(appType model.AppType) (string) {
+func getContentType(appType model.AppType) string {
 	switch appType {
 	case model.AppTypeAndroid:
 		return "application/vnd.android.package-archive"


### PR DESCRIPTION
I've been modifying https://github.com/bitrise-steplib/steps-appcenter-deploy-android to get all deploy groups if enabled and add them to the release (I had been using https://github.com/fileformat/bitrise-step-appcenter-app-release which does that by default).
I'd need to be able to retrieve all the groups info without any specific name, just all group assigned to the application.

In case this PR gets merged I have a PR ready as well for the appcenter deploy android to support it as well.